### PR TITLE
Improve `test_and_lint` workflow

### DIFF
--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -6,17 +6,19 @@ jobs:
   test_and_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         id: setup-python
         with:
           python-version: "3.9"
-      - run: pip install pipenv
-      - name: Cache virtualenvs
-        uses: actions/cache@v2
+          cache: "pipenv"
+      - name: Cache Pre-commit for format checking
+        uses: actions/cache@v3
         with:
-          path: ~/.local/share/virtualenvs/
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: pip install pipenv
       - run: pipenv sync --dev
+      - name: Check formatting using pre-commit hooks
+        run: pipenv run pre-commit run --all-files --show-diff-on-failure
       - run: pipenv run pytest
-      - run: pipenv run ./scripts/format_check.sh

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-isort --check --diff .
-black --check --diff .
-flake8 --extend-exclude .venv .


### PR DESCRIPTION
This PR:
* Uses inbuilt caching from the latest github actions for `setup-python`
* Uses `pre-commit` hooks for formatting instead of the `format_check.sh` script