### PR TITLE
Remove --keep-outdated flag in pipenv sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
         args: ["--py37-plus"]
       - id: nbqa-isort
         args: ["--float-to-top"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.971
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-pyyaml==6.0.11]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT ["python", "-m", "app"]
 
 FROM dependencies AS testrunner
 
-RUN pipenv sync --keep-outdated --dev
+RUN pipenv sync --dev
 ENV PYTEST_ADDOPTS="-p no:cacheprovider"
 COPY --chown=user . .
 RUN git init . && pipenv run pre-commit install-hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ USER user
 WORKDIR /home/user/src
 
 COPY --chown=user Pipfile* .
-RUN pipenv sync --keep-outdated
+RUN pipenv sync
 ENV PATH="/home/user/src/.venv/bin:$PATH"
 ENV PYTHONPATH=.
 


### PR DESCRIPTION
This is flagging error in docker builds. delete this. Also adds mypy to list of precommit checks so we can deprecate this PR:
https://github.com/centrefornetzero/python-template/pull/13